### PR TITLE
Hide donate dropdown menu button on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -564,4 +564,12 @@ justify-content: center;
 	margin-top: 0px;
 	}
 }
+
+/*
+This is a workaround to hide the Donate menu on mobile until the next release.
+*/
+.burger-menu-item:last-child {
+  display: none;
+}
+
 /* end p4 mvp */


### PR DESCRIPTION
Added this (temporary) workaround since you need to hide the donate dropdown menu button on Mobile.

Once it's released [this functionality](https://github.com/greenpeace/planet4-master-theme/pull/1689) you will need to remove this  piece of code.
